### PR TITLE
Support dynamic step arguments

### DIFF
--- a/R/forge-analysis.R
+++ b/R/forge-analysis.R
@@ -7,9 +7,12 @@
 #' @param group_col Column name of group information in the sample information.
 #'   Used for various analyses. Default is "group".
 #' @param ... Additional arguments passed to the underlying functions.
-#'   Use the format `pkg.func.arg`.
+#'   Two formats are supported:
+#'   - `step_id.pkg.func.arg` to target a specific step in the blueprint (highest priority).
+#'   - `pkg.func.arg` to provide defaults via the blueprint step constructor.
 #'   For example, if you want to pass argument `p_adj_method = "BH"` to `glystats::gly_limma()`
-#'   in [step_dea()], set `glystats.gly_limma.p_adj_method = "BH"`.
+#'   in [step_dea()], set `dea.glystats.gly_limma.p_adj_method = "BH"` in `forge_analysis()`
+#'   or `step_dea(glystats.gly_limma.p_adj_method = "BH")` when building the blueprint.
 #'   Note that arguments about group column specification is controlled by `group_col` argument,
 #'   and should not be passed to `...`.
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,6 +20,32 @@
   out
 }
 
+#' Collect dots for a step
+#'
+#' Combine step-level dots (from blueprint construction) and dots passed through
+#' `forge_analysis()` using the `step_id.pkg.fun.arg` convention. The latter has
+#' higher priority when both are supplied.
+#'
+#' @param step_id Step identifier.
+#' @param ctx_dots A dots list captured by `forge_analysis()`.
+#' @param step_dots A dots list captured by the step constructor.
+#'
+#' @returns A merged dots list for the step.
+#' @noRd
+.collect_step_dots <- function(step_id, ctx_dots, step_dots = list()) {
+  ctx_dots <- ctx_dots %||% list()
+  step_dots <- step_dots %||% list()
+
+  step_prefix <- paste0(step_id, ".")
+  from_forge <- ctx_dots[startsWith(names(ctx_dots), step_prefix)]
+  names(from_forge) <- substring(names(from_forge), nchar(step_prefix) + 1)
+
+  ctx_general <- ctx_dots[!startsWith(names(ctx_dots), step_prefix)]
+
+  merged <- utils::modifyList(step_dots, ctx_general)
+  utils::modifyList(merged, from_forge)
+}
+
 #' Run a glycoverse function with arguments from dots
 #'
 #' The function is a syntactic sugar for `rlang::exec(f, exp, !!!.get_args(pkg, func, dots))`,

--- a/tests/testthat/test-step-dots.R
+++ b/tests/testthat/test-step-dots.R
@@ -1,0 +1,33 @@
+test_that("blueprint dots are passed into steps", {
+  exp <- glyexp::real_experiment2
+  captured <- NULL
+
+  with_mocked_bindings({
+    bp <- blueprint(step_preprocess(glyclean.auto_clean.batch_col = "plate"))
+    forge_analysis(exp, blueprint = bp)
+  }, glyclean::auto_clean = function(exp, batch_col = NULL, ...) {
+    captured <<- batch_col
+    exp
+  })
+
+  expect_equal(captured, "plate")
+})
+
+test_that("forge_analysis dots override blueprint dots", {
+  exp <- glyexp::real_experiment2
+  captured <- NULL
+
+  with_mocked_bindings({
+    bp <- blueprint(step_preprocess(glyclean.auto_clean.batch_col = "blueprint"))
+    forge_analysis(
+      exp,
+      blueprint = bp,
+      preprocess.glyclean.auto_clean.batch_col = "forge"
+    )
+  }, glyclean::auto_clean = function(exp, batch_col = NULL, ...) {
+    captured <<- batch_col
+    exp
+  })
+
+  expect_equal(captured, "forge")
+})


### PR DESCRIPTION
## Summary
- allow step constructors to capture blueprint-level arguments and merge them with forge_analysis overrides
- add helper to collect step-specific dots so forge-supplied step-prefixed parameters take precedence
- cover blueprint and forge argument precedence with new tests

## Testing
- Rscript -e "devtools::test()" *(fails: Rscript not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694123ea9a588326af37e63bc6663023)