### PR TITLE
Support configurable AI providers in glysmith

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 ## New features
 
 * Add `step_infer_structure()` for inferring glycan structures from composition using `glyanno` (#13).
-* Add `step_sig_enrich_ncg()`, `step_sig_enrich_wp()`, and `step_sig_enrich_do()` functions (#14).
+* Add `step_sig_enrich_ncg()`, `step_sig_enrich_wp()`, and `step_sig_enrich_do()` functions for Network of Cancer Gene, WikiPathways, and Disease Ontology enrichment analysis, respectively (#14).
+* AI features now support more model providers including OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible models. The default model is still `deepseek-chat` (#15).
 
 ## Minor improvements and bug fixes
 

--- a/R/inquire-blueprint.R
+++ b/R/inquire-blueprint.R
@@ -2,10 +2,9 @@
 #'
 #' `r lifecycle::badge("experimental")`
 #' Ask a Large Language Model (LLM) to create a blueprint for glycomics or glycoproteomics data analysis.
-#' To use this function, you need to have a DeepSeek API key.
-#' You can get a DeepSeek API key from https://platform.deepseek.com.
-#' Then set the environment variable `DEEPSEEK_API_KEY` to your API key with
-#' `Sys.setenv(DEEPSEEK_API_KEY = "your-api-key")`.
+#' DeepSeek is used by default for backward compatibility. Other `ellmer`
+#' providers can be selected with `provider`, `model`, and provider-specific
+#' API key configuration.
 #'
 #' @details
 #' LLMs can be unstable. If you get an error, try again with another description.
@@ -27,32 +26,47 @@
 #' @param description A description of what you want to analysis.
 #' @param exp Optional. A `glyexp::experiment()` object to provide more context to the LLM.
 #' @param group_col The column name of the group variable in the experiment. Default to "group".
-#' @param model Model to use. Default to "deepseek-chat".
 #' @param max_retries Maximum number of retries when the AI output is invalid. Default to 3.
+#' @param model Model to use. Defaults to "deepseek-chat" for DeepSeek and
+#'   the provider default for other providers.
+#' @param provider AI provider passed to `ellmer`. One of "deepseek",
+#'   "openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
+#'   Default to "deepseek".
+#' @param api_key API key for the selected provider. If `NULL`, the provider
+#'   specific environment variable is used.
+#' @param base_url Optional base URL for custom or OpenAI-compatible endpoints.
 #'
 #' @export
 inquire_blueprint <- function(
   description,
   exp = NULL,
   group_col = "group",
-  model = "deepseek-chat",
-  max_retries = 3
+  model = NULL,
+  max_retries = 3,
+  provider = "deepseek",
+  api_key = NULL,
+  base_url = NULL
 ) {
   checkmate::assert_string(description)
   checkmate::assert_class(exp, "glyexp_experiment", null.ok = TRUE)
   checkmate::assert_string(group_col)
-  checkmate::assert_choice(model, c("deepseek-reasoner", "deepseek-chat"))
+  checkmate::assert_string(model, null.ok = TRUE)
   checkmate::assert_count(max_retries)
+  provider <- .normalize_ai_provider(provider)
+  checkmate::assert_string(api_key, null.ok = TRUE)
+  checkmate::assert_string(base_url, null.ok = TRUE)
   rlang::check_installed("ellmer")
 
-  api_key <- .get_api_key()
+  model <- .resolve_ai_model(provider, model)
+  api_key <- .get_api_key(provider = provider, api_key = api_key)
   system_prompt <- .inquire_blueprint_sys_prompt()
 
-  chat <- ellmer::chat_deepseek(
+  chat <- .create_ai_chat(
     system_prompt = system_prompt,
+    api_key = api_key,
+    provider = provider,
     model = model,
-    echo = "none",
-    credentials = function() api_key
+    base_url = base_url
   )
 
   # Initial prompt with dataset info
@@ -67,7 +81,12 @@ inquire_blueprint <- function(
   max_questions <- 20L
 
   # Print fun fact only once at the start
-  .print_ai_thinking(api_key)
+  .print_ai_thinking(
+    api_key,
+    provider = provider,
+    model = model,
+    base_url = base_url
+  )
 
   repeat {
     if (retry_count > 0) {
@@ -110,6 +129,9 @@ inquire_blueprint <- function(
         exp = exp,
         group_col = group_col,
         model = model,
+        provider = provider,
+        api_key = api_key,
+        base_url = base_url,
         max_retries = max_retries
       ))
     }
@@ -602,6 +624,9 @@ inquire_blueprint <- function(
 #' @param exp Optional experiment metadata passed to [modify_blueprint()].
 #' @param group_col Group column name passed to [modify_blueprint()].
 #' @param model Model name passed to [modify_blueprint()].
+#' @param provider AI provider passed to [modify_blueprint()].
+#' @param api_key API key passed to [modify_blueprint()].
+#' @param base_url Base URL passed to [modify_blueprint()].
 #' @param max_retries Maximum retries passed to [modify_blueprint()].
 #'
 #' @returns A confirmed `glysmith_blueprint` object.
@@ -613,6 +638,9 @@ inquire_blueprint <- function(
   exp,
   group_col,
   model,
+  provider = "deepseek",
+  api_key = NULL,
+  base_url = NULL,
   max_retries
 ) {
   checkmate::assert_class(bp, "glysmith_blueprint")
@@ -636,6 +664,9 @@ inquire_blueprint <- function(
       exp = exp,
       group_col = group_col,
       model = model,
+      provider = provider,
+      api_key = api_key,
+      base_url = base_url,
       max_retries = max_retries
     )
   }

--- a/R/inquire-blueprint.R
+++ b/R/inquire-blueprint.R
@@ -27,25 +27,27 @@
 #' @param exp Optional. A `glyexp::experiment()` object to provide more context to the LLM.
 #' @param group_col The column name of the group variable in the experiment. Default to "group".
 #' @param max_retries Maximum number of retries when the AI output is invalid. Default to 3.
-#' @param model Model to use. Defaults to "deepseek-chat" for DeepSeek and
-#'   the provider default for other providers.
+#' @param model Model to use. Defaults to `getOption("glysmith.ai_model")`,
+#'   or "deepseek-chat" for DeepSeek and the provider default for other providers.
 #' @param provider AI provider passed to `ellmer`. One of "deepseek",
 #'   "openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
-#'   Default to "deepseek".
+#'   Defaults to `getOption("glysmith.ai_provider", "deepseek")`.
 #' @param api_key API key for the selected provider. If `NULL`, the provider
-#'   specific environment variable is used.
+#'   specific environment variable is used. Defaults to
+#'   `getOption("glysmith.ai_api_key")`.
 #' @param base_url Optional base URL for custom or OpenAI-compatible endpoints.
+#'   Defaults to `getOption("glysmith.ai_base_url")`.
 #'
 #' @export
 inquire_blueprint <- function(
   description,
   exp = NULL,
   group_col = "group",
-  model = NULL,
+  model = getOption("glysmith.ai_model", NULL),
   max_retries = 3,
-  provider = "deepseek",
-  api_key = NULL,
-  base_url = NULL
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  api_key = getOption("glysmith.ai_api_key", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   checkmate::assert_string(description)
   checkmate::assert_class(exp, "glyexp_experiment", null.ok = TRUE)
@@ -638,9 +640,9 @@ inquire_blueprint <- function(
   exp,
   group_col,
   model,
-  provider = "deepseek",
-  api_key = NULL,
-  base_url = NULL,
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  api_key = getOption("glysmith.ai_api_key", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL),
   max_retries
 ) {
   checkmate::assert_class(bp, "glysmith_blueprint")

--- a/R/modify-blueprint.R
+++ b/R/modify-blueprint.R
@@ -19,14 +19,16 @@
 #' @param exp Optional. A `glyexp::experiment()` object to provide more context to the LLM.
 #' @param group_col The column name of the group variable in the experiment. Default to "group".
 #' @param max_retries Maximum number of retries when the AI output is invalid. Default to 3.
-#' @param model Model to use. Defaults to "deepseek-chat" for DeepSeek and
-#'   the provider default for other providers.
+#' @param model Model to use. Defaults to `getOption("glysmith.ai_model")`,
+#'   or "deepseek-chat" for DeepSeek and the provider default for other providers.
 #' @param provider AI provider passed to `ellmer`. One of "deepseek",
 #'   "openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
-#'   Default to "deepseek".
+#'   Defaults to `getOption("glysmith.ai_provider", "deepseek")`.
 #' @param api_key API key for the selected provider. If `NULL`, the provider
-#'   specific environment variable is used.
+#'   specific environment variable is used. Defaults to
+#'   `getOption("glysmith.ai_api_key")`.
 #' @param base_url Optional base URL for custom or OpenAI-compatible endpoints.
+#'   Defaults to `getOption("glysmith.ai_base_url")`.
 #'
 #' @export
 modify_blueprint <- function(
@@ -35,11 +37,11 @@ modify_blueprint <- function(
   qa_history = NULL,
   exp = NULL,
   group_col = "group",
-  model = NULL,
+  model = getOption("glysmith.ai_model", NULL),
   max_retries = 3,
-  provider = "deepseek",
-  api_key = NULL,
-  base_url = NULL
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  api_key = getOption("glysmith.ai_api_key", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   checkmate::assert_class(bp, "glysmith_blueprint")
   checkmate::assert_string(description)

--- a/R/modify-blueprint.R
+++ b/R/modify-blueprint.R
@@ -2,10 +2,9 @@
 #'
 #' `r lifecycle::badge("experimental")`
 #' Ask a Large Language Model (LLM) to modify an existing blueprint for glycomics
-#' or glycoproteomics data analysis. To use this function, you need to have a
-#' DeepSeek API key. You can get a DeepSeek API key from https://platform.deepseek.com.
-#' Then set the environment variable `DEEPSEEK_API_KEY` to your API key with
-#' `Sys.setenv(DEEPSEEK_API_KEY = "your-api-key")`.
+#' or glycoproteomics data analysis. DeepSeek is used by default for backward
+#' compatibility. Other `ellmer` providers can be selected with `provider`,
+#' `model`, and provider-specific API key configuration.
 #'
 #' @details
 #' LLMs can be unstable. If you get an error, try again with another description.
@@ -19,8 +18,15 @@
 #' @param qa_history Character vector of Q&A pairs from [inquire_blueprint()].
 #' @param exp Optional. A `glyexp::experiment()` object to provide more context to the LLM.
 #' @param group_col The column name of the group variable in the experiment. Default to "group".
-#' @param model Model to use. Default to "deepseek-chat".
 #' @param max_retries Maximum number of retries when the AI output is invalid. Default to 3.
+#' @param model Model to use. Defaults to "deepseek-chat" for DeepSeek and
+#'   the provider default for other providers.
+#' @param provider AI provider passed to `ellmer`. One of "deepseek",
+#'   "openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
+#'   Default to "deepseek".
+#' @param api_key API key for the selected provider. If `NULL`, the provider
+#'   specific environment variable is used.
+#' @param base_url Optional base URL for custom or OpenAI-compatible endpoints.
 #'
 #' @export
 modify_blueprint <- function(
@@ -29,26 +35,34 @@ modify_blueprint <- function(
   qa_history = NULL,
   exp = NULL,
   group_col = "group",
-  model = "deepseek-chat",
-  max_retries = 3
+  model = NULL,
+  max_retries = 3,
+  provider = "deepseek",
+  api_key = NULL,
+  base_url = NULL
 ) {
   checkmate::assert_class(bp, "glysmith_blueprint")
   checkmate::assert_string(description)
   checkmate::assert_character(qa_history, null.ok = TRUE)
   checkmate::assert_class(exp, "glyexp_experiment", null.ok = TRUE)
   checkmate::assert_string(group_col)
-  checkmate::assert_choice(model, c("deepseek-reasoner", "deepseek-chat"))
+  checkmate::assert_string(model, null.ok = TRUE)
   checkmate::assert_count(max_retries)
+  provider <- .normalize_ai_provider(provider)
+  checkmate::assert_string(api_key, null.ok = TRUE)
+  checkmate::assert_string(base_url, null.ok = TRUE)
   rlang::check_installed("ellmer")
 
-  api_key <- .get_api_key()
+  model <- .resolve_ai_model(provider, model)
+  api_key <- .get_api_key(provider = provider, api_key = api_key)
   system_prompt <- .modify_blueprint_sys_prompt()
 
-  chat <- ellmer::chat_deepseek(
+  chat <- .create_ai_chat(
     system_prompt = system_prompt,
+    api_key = api_key,
+    provider = provider,
     model = model,
-    echo = "none",
-    credentials = function() api_key
+    base_url = base_url
   )
 
   exp_info <- .generate_exp_info(exp, group_col)
@@ -80,7 +94,12 @@ modify_blueprint <- function(
   max_questions <- 20L
 
   # Print fun fact only once at the start
-  .print_ai_thinking(api_key)
+  .print_ai_thinking(
+    api_key,
+    provider = provider,
+    model = model,
+    base_url = base_url
+  )
 
   repeat {
     if (retry_count > 0) {

--- a/R/polish-report.R
+++ b/R/polish-report.R
@@ -2,18 +2,24 @@
 #'
 #' Generate a self-contained HTML report for a `glysmith_result` object.
 #' The report is rendered via `rmarkdown::render()` using an internal R Markdown template.
-#' If `use_ai` is TRUE, the report text will be polished and organized into sections using LLM (deepseek-chat),
-#' and plots will be described with a multimodal model (deepseek-vl-chat).
-#' To use this feature, you have to provide an API key and set it in the environment variable `DEEPSEEK_API_KEY`
-#' by running `Sys.setenv(DEEPSEEK_API_KEY = "your_api_key")`.
-#' You can apply the API key on https://platform.deepseek.com.
+#' If `use_ai` is TRUE, the report text will be polished, organized into
+#' sections, and paired with plot descriptions using the configured `ellmer`
+#' provider. DeepSeek is used by default for backward compatibility.
 #'
 #' @param x A `glysmith_result` object.
 #' @param output_file Path to the output HTML file.
 #' @param title Report title.
 #' @param open Whether to open the report in a browser after rendering.
 #' @param use_ai Whether to polish the report text, organize sections, and generate plot descriptions using AI
-#'   (deepseek-chat and deepseek-vision). Default is FALSE.
+#'   with the configured `ellmer` provider. Default is FALSE.
+#' @param ai_provider AI provider passed to `ellmer` when `use_ai = TRUE`.
+#'   One of "deepseek", "openai", "anthropic", "gemini", "openrouter", or
+#'   "openai_compatible". Default to "deepseek".
+#' @param ai_model AI model to use when `use_ai = TRUE`. Defaults to
+#'   "deepseek-chat" for DeepSeek and the provider default for other providers.
+#' @param ai_api_key API key for the selected provider. If `NULL`, the provider
+#'   specific environment variable is used.
+#' @param ai_base_url Optional base URL for custom or OpenAI-compatible endpoints.
 #'
 #' @returns The normalized path to the generated HTML file.
 #' @examples
@@ -28,13 +34,21 @@ polish_report <- function(
   output_file,
   title = "GlySmith report",
   open = interactive(),
-  use_ai = FALSE
+  use_ai = FALSE,
+  ai_provider = "deepseek",
+  ai_model = NULL,
+  ai_api_key = NULL,
+  ai_base_url = NULL
 ) {
   checkmate::assert_class(x, "glysmith_result")
   checkmate::assert_string(output_file)
   checkmate::assert_string(title)
   checkmate::assert_flag(open)
   checkmate::assert_flag(use_ai)
+  ai_provider <- .normalize_ai_provider(ai_provider)
+  checkmate::assert_string(ai_model, null.ok = TRUE)
+  checkmate::assert_string(ai_api_key, null.ok = TRUE)
+  checkmate::assert_string(ai_base_url, null.ok = TRUE)
 
   template <- system.file(
     "templates",
@@ -64,7 +78,14 @@ polish_report <- function(
   tmp_rmd <- fs::path(tmp_dir, "polish_report.Rmd")
   fs::file_copy(template, tmp_rmd, overwrite = TRUE)
 
-  report_sections <- .build_report_sections(x, use_ai = use_ai)
+  report_sections <- .build_report_sections(
+    x,
+    use_ai = use_ai,
+    provider = ai_provider,
+    model = ai_model,
+    api_key = ai_api_key,
+    base_url = ai_base_url
+  )
 
   rendered <- rmarkdown::render(
     input = tmp_rmd,
@@ -93,7 +114,14 @@ polish_report <- function(
 #' @param x A glysmith_result object.
 #' @param use_ai Whether to polish content using AI.
 #' @noRd
-.build_step_reports <- function(x, use_ai = FALSE, api_key = NULL) {
+.build_step_reports <- function(
+  x,
+  use_ai = FALSE,
+  api_key = NULL,
+  provider = "deepseek",
+  model = NULL,
+  base_url = NULL
+) {
   steps_executed <- character(0)
   if (!is.null(x$meta) && is.list(x$meta) && !is.null(x$meta$steps)) {
     steps_executed <- x$meta$steps
@@ -104,9 +132,10 @@ polish_report <- function(
 
   if (isTRUE(use_ai)) {
     if (is.null(api_key)) {
-      api_key <- .get_api_key()
+      api_key <- .get_api_key(provider = provider)
     }
-    cli::cli_alert_info("Polishing report text with AI (deepseek-chat)...")
+    provider_label <- .ai_provider_label(provider)
+    cli::cli_alert_info("Polishing report text with AI ({provider_label})...")
   }
 
   purrr::map(ids, function(id) {
@@ -131,7 +160,13 @@ polish_report <- function(
 
     # Apply AI polishing if enabled and content is not empty
     if (isTRUE(use_ai)) {
-      content <- .polish_text(content, api_key)
+      content <- .polish_text(
+        content,
+        api_key,
+        model = model,
+        provider = provider,
+        base_url = base_url
+      )
     } else {
       content <- stringr::str_remove_all(content, "<AI>[\\s\\S]*?</AI>")
     }
@@ -147,21 +182,46 @@ polish_report <- function(
 #' @param x A glysmith_result object.
 #' @param use_ai Whether to organize sections with AI.
 #' @noRd
-.build_report_sections <- function(x, use_ai = FALSE) {
-  api_key <- NULL
-  if (isTRUE(use_ai)) {
-    api_key <- .get_api_key()
+.build_report_sections <- function(
+  x,
+  use_ai = FALSE,
+  provider = "deepseek",
+  model = NULL,
+  api_key = NULL,
+  base_url = NULL
+) {
+  provider <- .normalize_ai_provider(provider)
+  model <- .resolve_ai_model(provider, model)
+  if (isTRUE(use_ai) && is.null(api_key)) {
+    api_key <- .get_api_key(provider = provider)
   }
 
-  step_reports <- .build_step_reports(x, use_ai = use_ai, api_key = api_key)
-  plot_entries <- .build_plot_entries(x, use_ai = use_ai, api_key = api_key)
+  step_reports <- .build_step_reports(
+    x,
+    use_ai = use_ai,
+    api_key = api_key,
+    provider = provider,
+    model = model,
+    base_url = base_url
+  )
+  plot_entries <- .build_plot_entries(
+    x,
+    use_ai = use_ai,
+    api_key = api_key,
+    provider = provider,
+    model = model,
+    base_url = base_url
+  )
 
   section_plan <- NULL
   if (isTRUE(use_ai)) {
     section_plan <- .organize_report_sections(
       step_reports,
       plot_entries,
-      api_key
+      api_key,
+      provider = provider,
+      model = model,
+      base_url = base_url
     )
   }
 
@@ -176,7 +236,14 @@ polish_report <- function(
 #'
 #' @param x A glysmith_result object.
 #' @noRd
-.build_plot_entries <- function(x, use_ai = FALSE, api_key = NULL) {
+.build_plot_entries <- function(
+  x,
+  use_ai = FALSE,
+  api_key = NULL,
+  provider = "deepseek",
+  model = NULL,
+  base_url = NULL
+) {
   plots <- x$plots
   if (is.null(plots)) {
     return(list())
@@ -188,11 +255,12 @@ polish_report <- function(
   }
 
   if (isTRUE(use_ai) && is.null(api_key)) {
-    api_key <- .get_api_key()
+    api_key <- .get_api_key(provider = provider)
   }
 
   if (isTRUE(use_ai) && length(plots) > 0) {
-    cli::cli_alert_info("Generating AI plot descriptions (deepseek-vl-chat)...")
+    provider_label <- .ai_provider_label(provider)
+    cli::cli_alert_info("Generating AI plot descriptions ({provider_label})...")
   }
 
   purrr::imap(plots, function(p, id) {
@@ -236,7 +304,10 @@ polish_report <- function(
         desc,
         api_key,
         width = width,
-        height = height
+        height = height,
+        model = model,
+        provider = provider,
+        base_url = base_url
       )
     }
     desc <- .humanize_plot_description(desc)
@@ -368,7 +439,9 @@ polish_report <- function(
   api_key,
   width = NULL,
   height = NULL,
-  model = "deepseek-chat"
+  model = NULL,
+  provider = "deepseek",
+  base_url = NULL
 ) {
   if (is.null(plot)) {
     return(description)
@@ -404,7 +477,9 @@ polish_report <- function(
         user_prompt,
         content,
         api_key,
-        model
+        model,
+        provider = provider,
+        base_url = base_url
       )
       response <- stringr::str_squish(response)
       if (!nzchar(response)) {
@@ -527,7 +602,9 @@ polish_report <- function(
   step_reports,
   plot_entries,
   api_key,
-  model = "deepseek-chat"
+  provider = "deepseek",
+  model = NULL,
+  base_url = NULL
 ) {
   if (length(step_reports) == 0 && length(plot_entries) == 0) {
     return(NULL)
@@ -583,7 +660,14 @@ polish_report <- function(
   )
 
   output <- tryCatch(
-    .ask_ai(system_prompt, user_prompt, api_key, model),
+    .ask_ai(
+      system_prompt,
+      user_prompt,
+      api_key,
+      model = model,
+      provider = provider,
+      base_url = base_url
+    ),
     error = function(e) {
       cli::cli_warn(c(
         "AI section organization failed, using default order.",
@@ -1044,7 +1128,13 @@ polish_report <- function(
 #' @param model The AI model to use.
 #' @return The polished text, or original text if polishing fails.
 #' @noRd
-.polish_text <- function(text, api_key, model = "deepseek-chat") {
+.polish_text <- function(
+  text,
+  api_key,
+  model = NULL,
+  provider = "deepseek",
+  base_url = NULL
+) {
   if (is.null(text) || !nzchar(text)) {
     return(text)
   }
@@ -1063,7 +1153,14 @@ polish_report <- function(
   )
 
   tryCatch(
-    .ask_ai(system_prompt, text, api_key, model),
+    .ask_ai(
+      system_prompt,
+      text,
+      api_key,
+      model = model,
+      provider = provider,
+      base_url = base_url
+    ),
     error = function(e) {
       cli::cli_warn(c(
         "AI polishing failed, using original text.",

--- a/R/polish-report.R
+++ b/R/polish-report.R
@@ -14,12 +14,16 @@
 #'   with the configured `ellmer` provider. Default is FALSE.
 #' @param ai_provider AI provider passed to `ellmer` when `use_ai = TRUE`.
 #'   One of "deepseek", "openai", "anthropic", "gemini", "openrouter", or
-#'   "openai_compatible". Default to "deepseek".
+#'   "openai_compatible". Defaults to
+#'   `getOption("glysmith.ai_provider", "deepseek")`.
 #' @param ai_model AI model to use when `use_ai = TRUE`. Defaults to
-#'   "deepseek-chat" for DeepSeek and the provider default for other providers.
+#'   `getOption("glysmith.ai_model")`, or "deepseek-chat" for DeepSeek and
+#'   the provider default for other providers.
 #' @param ai_api_key API key for the selected provider. If `NULL`, the provider
-#'   specific environment variable is used.
+#'   specific environment variable is used. Defaults to
+#'   `getOption("glysmith.ai_api_key")`.
 #' @param ai_base_url Optional base URL for custom or OpenAI-compatible endpoints.
+#'   Defaults to `getOption("glysmith.ai_base_url")`.
 #'
 #' @returns The normalized path to the generated HTML file.
 #' @examples
@@ -35,10 +39,10 @@ polish_report <- function(
   title = "GlySmith report",
   open = interactive(),
   use_ai = FALSE,
-  ai_provider = "deepseek",
-  ai_model = NULL,
-  ai_api_key = NULL,
-  ai_base_url = NULL
+  ai_provider = getOption("glysmith.ai_provider", "deepseek"),
+  ai_model = getOption("glysmith.ai_model", NULL),
+  ai_api_key = getOption("glysmith.ai_api_key", NULL),
+  ai_base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   checkmate::assert_class(x, "glysmith_result")
   checkmate::assert_string(output_file)
@@ -118,9 +122,9 @@ polish_report <- function(
   x,
   use_ai = FALSE,
   api_key = NULL,
-  provider = "deepseek",
-  model = NULL,
-  base_url = NULL
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  model = getOption("glysmith.ai_model", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   steps_executed <- character(0)
   if (!is.null(x$meta) && is.list(x$meta) && !is.null(x$meta$steps)) {
@@ -185,10 +189,10 @@ polish_report <- function(
 .build_report_sections <- function(
   x,
   use_ai = FALSE,
-  provider = "deepseek",
-  model = NULL,
-  api_key = NULL,
-  base_url = NULL
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  model = getOption("glysmith.ai_model", NULL),
+  api_key = getOption("glysmith.ai_api_key", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   provider <- .normalize_ai_provider(provider)
   model <- .resolve_ai_model(provider, model)
@@ -240,9 +244,9 @@ polish_report <- function(
   x,
   use_ai = FALSE,
   api_key = NULL,
-  provider = "deepseek",
-  model = NULL,
-  base_url = NULL
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  model = getOption("glysmith.ai_model", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   plots <- x$plots
   if (is.null(plots)) {
@@ -439,9 +443,9 @@ polish_report <- function(
   api_key,
   width = NULL,
   height = NULL,
-  model = NULL,
-  provider = "deepseek",
-  base_url = NULL
+  model = getOption("glysmith.ai_model", NULL),
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   if (is.null(plot)) {
     return(description)
@@ -602,9 +606,9 @@ polish_report <- function(
   step_reports,
   plot_entries,
   api_key,
-  provider = "deepseek",
-  model = NULL,
-  base_url = NULL
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  model = getOption("glysmith.ai_model", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   if (length(step_reports) == 0 && length(plot_entries) == 0) {
     return(NULL)
@@ -1131,9 +1135,9 @@ polish_report <- function(
 .polish_text <- function(
   text,
   api_key,
-  model = NULL,
-  provider = "deepseek",
-  base_url = NULL
+  model = getOption("glysmith.ai_model", NULL),
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   if (is.null(text) || !nzchar(text)) {
     return(text)

--- a/R/utils.R
+++ b/R/utils.R
@@ -189,7 +189,9 @@
 #' @param provider Provider name or supported alias.
 #' @returns Canonical provider name.
 #' @noRd
-.normalize_ai_provider <- function(provider = "deepseek") {
+.normalize_ai_provider <- function(
+  provider = getOption("glysmith.ai_provider", "deepseek")
+) {
   provider <- rlang::arg_match(provider, .ai_provider_choices())
   if (identical(provider, "google_gemini")) {
     return("gemini")
@@ -237,7 +239,10 @@
 #' @param model Optional model name supplied by the caller.
 #' @returns Model name, or `NULL` to use the provider default.
 #' @noRd
-.resolve_ai_model <- function(provider = "deepseek", model = NULL) {
+.resolve_ai_model <- function(
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  model = getOption("glysmith.ai_model", NULL)
+) {
   provider <- .normalize_ai_provider(provider)
   if (!is.null(model)) {
     return(model)
@@ -254,7 +259,10 @@
 #' @param api_key Optional explicit API key.
 #' @returns API key string.
 #' @noRd
-.get_api_key <- function(provider = "deepseek", api_key = NULL) {
+.get_api_key <- function(
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  api_key = getOption("glysmith.ai_api_key", NULL)
+) {
   if (!is.null(api_key)) {
     return(api_key)
   }
@@ -284,9 +292,9 @@
 .create_ai_chat <- function(
   system_prompt,
   api_key,
-  provider = "deepseek",
-  model = NULL,
-  base_url = NULL
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  model = getOption("glysmith.ai_model", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   rlang::check_installed("ellmer")
   provider <- .normalize_ai_provider(provider)
@@ -340,9 +348,9 @@
   system_prompt,
   user_prompt,
   api_key,
-  model = NULL,
-  provider = "deepseek",
-  base_url = NULL
+  model = getOption("glysmith.ai_model", NULL),
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   chat <- .create_ai_chat(
     system_prompt = system_prompt,
@@ -370,9 +378,9 @@
   user_prompt,
   content,
   api_key,
-  model = NULL,
-  provider = "deepseek",
-  base_url = NULL
+  model = getOption("glysmith.ai_model", NULL),
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 ) {
   chat <- .create_ai_chat(
     system_prompt = system_prompt,

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,7 +24,19 @@
   readline(prompt = prompt)
 }
 
-.print_ai_thinking <- function(api_key) {
+#' Print an AI progress message and glycan fact
+#'
+#' @param api_key API key for the selected AI provider.
+#' @param provider AI provider name.
+#' @param model Optional model name.
+#' @param base_url Optional provider base URL.
+#' @noRd
+.print_ai_thinking <- function(
+  api_key,
+  provider = "deepseek",
+  model = NULL,
+  base_url = NULL
+) {
   messages <- c(
     "Forging the blueprint...",
     "Hammering out the details...",
@@ -39,14 +51,32 @@
   )
   cli::cli_text(cli::style_bold(cli::col_blue(sample(messages, 1))))
   fact <- tryCatch(
-    .generate_glycan_fact(api_key),
+    .generate_glycan_fact(
+      api_key,
+      provider = provider,
+      model = model,
+      base_url = base_url
+    ),
     error = function(e) .glycan_fun_fact()
   )
   styled_fact <- cli::style_italic(cli::col_silver(fact))
   cli::cli_text("{fact}", .envir = rlang::env(fact = styled_fact))
 }
 
-.generate_glycan_fact <- function(api_key, model = "deepseek-chat") {
+#' Generate a short glycan fact with the configured AI provider
+#'
+#' @param api_key API key for the selected AI provider.
+#' @param model Optional model name.
+#' @param provider AI provider name.
+#' @param base_url Optional provider base URL.
+#' @returns A normalized one-sentence glycan fact.
+#' @noRd
+.generate_glycan_fact <- function(
+  api_key,
+  model = NULL,
+  provider = "deepseek",
+  base_url = NULL
+) {
   focus <- sample(
     c(
       "structural diversity",
@@ -89,10 +119,22 @@
     "Random seed:",
     nonce
   )
-  fact <- .ask_ai(system_prompt, user_prompt, api_key, model = model)
+  fact <- .ask_ai(
+    system_prompt,
+    user_prompt,
+    api_key,
+    model = model,
+    provider = provider,
+    base_url = base_url
+  )
   .normalize_glycan_fact(fact)
 }
 
+#' Normalize AI-generated glycan fact text
+#'
+#' @param fact Raw fact text returned by the AI provider.
+#' @returns A single question beginning with "Do you know that".
+#' @noRd
 .normalize_glycan_fact <- function(fact) {
   fact <- stringr::str_squish(as.character(fact))
   fact <- stringr::str_remove(fact, "^[-*]\\s*")
@@ -111,6 +153,10 @@
   fact
 }
 
+#' Return a local fallback glycan fact
+#'
+#' @returns A one-sentence glycan fact.
+#' @noRd
 .glycan_fun_fact <- function() {
   facts <- c(
     "Do you know that glycans can be branched, creating huge diversity from a small set of monosaccharides?",
@@ -122,47 +168,218 @@
   sample(facts, 1)
 }
 
-.get_api_key <- function() {
-  api_key <- Sys.getenv("DEEPSEEK_API_KEY")
+#' Supported AI provider names
+#'
+#' @returns Character vector of provider choices accepted by glysmith.
+#' @noRd
+.ai_provider_choices <- function() {
+  c(
+    "deepseek",
+    "openai",
+    "anthropic",
+    "gemini",
+    "google_gemini",
+    "openrouter",
+    "openai_compatible"
+  )
+}
+
+#' Normalize AI provider aliases
+#'
+#' @param provider Provider name or supported alias.
+#' @returns Canonical provider name.
+#' @noRd
+.normalize_ai_provider <- function(provider = "deepseek") {
+  provider <- rlang::arg_match(provider, .ai_provider_choices())
+  if (identical(provider, "google_gemini")) {
+    return("gemini")
+  }
+  provider
+}
+
+#' Human-readable AI provider label
+#'
+#' @param provider Provider name.
+#' @returns Provider label for messages.
+#' @noRd
+.ai_provider_label <- function(provider) {
+  switch(
+    .normalize_ai_provider(provider),
+    deepseek = "DeepSeek",
+    openai = "OpenAI",
+    anthropic = "Anthropic",
+    gemini = "Google Gemini",
+    openrouter = "OpenRouter",
+    openai_compatible = "OpenAI-compatible"
+  )
+}
+
+#' Environment variable for an AI provider API key
+#'
+#' @param provider Provider name.
+#' @returns Environment variable name.
+#' @noRd
+.ai_provider_envvar <- function(provider) {
+  switch(
+    .normalize_ai_provider(provider),
+    deepseek = "DEEPSEEK_API_KEY",
+    openai = "OPENAI_API_KEY",
+    anthropic = "ANTHROPIC_API_KEY",
+    gemini = "GEMINI_API_KEY",
+    openrouter = "OPENROUTER_API_KEY",
+    openai_compatible = "OPENAI_API_KEY"
+  )
+}
+
+#' Resolve the default AI model for a provider
+#'
+#' @param provider Provider name.
+#' @param model Optional model name supplied by the caller.
+#' @returns Model name, or `NULL` to use the provider default.
+#' @noRd
+.resolve_ai_model <- function(provider = "deepseek", model = NULL) {
+  provider <- .normalize_ai_provider(provider)
+  if (!is.null(model)) {
+    return(model)
+  }
+  if (identical(provider, "deepseek")) {
+    return("deepseek-chat")
+  }
+  NULL
+}
+
+#' Resolve an AI API key
+#'
+#' @param provider Provider name.
+#' @param api_key Optional explicit API key.
+#' @returns API key string.
+#' @noRd
+.get_api_key <- function(provider = "deepseek", api_key = NULL) {
+  if (!is.null(api_key)) {
+    return(api_key)
+  }
+  provider <- .normalize_ai_provider(provider)
+  envvar <- .ai_provider_envvar(provider)
+  api_key <- Sys.getenv(envvar)
   if (api_key == "") {
+    label <- .ai_provider_label(provider)
     cli::cli_abort(c(
-      "API key for DeepSeek chat model is not set.",
-      "i" = "Please set the environment variable `DEEPSEEK_API_KEY` to your API key.",
-      "i" = "You can obtain an API key from https://platform.deepseek.com."
+      "API key for {label} chat model is not set.",
+      "i" = "Please set the environment variable `{envvar}` to your API key, or pass `api_key` directly.",
+      "i" = "For OpenAI-compatible endpoints, set `OPENAI_API_KEY` and pass `base_url`."
     ))
   }
   api_key
 }
 
-.ask_ai <- function(
+#' Create an ellmer chat object for a configured provider
+#'
+#' @param system_prompt System prompt for the chat object.
+#' @param api_key API key for the selected provider.
+#' @param provider Provider name.
+#' @param model Optional model name.
+#' @param base_url Optional provider base URL.
+#' @returns An `ellmer` chat object.
+#' @noRd
+.create_ai_chat <- function(
   system_prompt,
-  user_prompt,
   api_key,
-  model = "deepseek-chat"
+  provider = "deepseek",
+  model = NULL,
+  base_url = NULL
 ) {
   rlang::check_installed("ellmer")
-  chat <- ellmer::chat_deepseek(
+  provider <- .normalize_ai_provider(provider)
+  model <- .resolve_ai_model(provider, model)
+
+  args <- list(
     system_prompt = system_prompt,
     model = model,
     echo = "none",
     credentials = function() api_key
   )
+  if (is.null(model)) {
+    args$model <- NULL
+  }
+
+  chat_fun <- switch(
+    provider,
+    deepseek = ellmer::chat_deepseek,
+    openai = ellmer::chat_openai,
+    anthropic = ellmer::chat_anthropic,
+    gemini = ellmer::chat_google_gemini,
+    openrouter = ellmer::chat_openrouter,
+    openai_compatible = ellmer::chat_openai_compatible
+  )
+
+  if (identical(provider, "openai_compatible")) {
+    if (is.null(base_url)) {
+      cli::cli_abort(
+        "`base_url` is required when `provider = \"openai_compatible\"`."
+      )
+    }
+    args <- c(list(base_url = base_url, name = "OpenAI-compatible"), args)
+  } else if (!is.null(base_url)) {
+    args$base_url <- base_url
+  }
+
+  do.call(chat_fun, args)
+}
+
+#' Send a text-only AI request
+#'
+#' @param system_prompt System prompt for the AI request.
+#' @param user_prompt User prompt for the AI request.
+#' @param api_key API key for the selected provider.
+#' @param model Optional model name.
+#' @param provider Provider name.
+#' @param base_url Optional provider base URL.
+#' @returns Character AI response.
+#' @noRd
+.ask_ai <- function(
+  system_prompt,
+  user_prompt,
+  api_key,
+  model = NULL,
+  provider = "deepseek",
+  base_url = NULL
+) {
+  chat <- .create_ai_chat(
+    system_prompt = system_prompt,
+    api_key = api_key,
+    provider = provider,
+    model = model,
+    base_url = base_url
+  )
   as.character(chat$chat(user_prompt))
 }
 
+#' Send a multimodal AI request
+#'
+#' @param system_prompt System prompt for the AI request.
+#' @param user_prompt User prompt for the AI request.
+#' @param content Multimodal content passed to `ellmer`.
+#' @param api_key API key for the selected provider.
+#' @param model Optional model name.
+#' @param provider Provider name.
+#' @param base_url Optional provider base URL.
+#' @returns Character AI response.
+#' @noRd
 .ask_ai_multimodal <- function(
   system_prompt,
   user_prompt,
   content,
   api_key,
-  model = "deepseek-chat"
+  model = NULL,
+  provider = "deepseek",
+  base_url = NULL
 ) {
-  rlang::check_installed("ellmer")
-  chat <- ellmer::chat_deepseek(
+  chat <- .create_ai_chat(
     system_prompt = system_prompt,
+    api_key = api_key,
+    provider = provider,
     model = model,
-    echo = "none",
-    credentials = function() api_key
+    base_url = base_url
   )
   as.character(chat$chat(content, user_prompt))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -263,7 +263,7 @@
   provider = getOption("glysmith.ai_provider", "deepseek"),
   api_key = getOption("glysmith.ai_api_key", NULL)
 ) {
-  if (!is.null(api_key)) {
+  if (!is.null(api_key) && nzchar(api_key)) {
     return(api_key)
   }
   provider <- .normalize_ai_provider(provider)

--- a/man/inquire_blueprint.Rd
+++ b/man/inquire_blueprint.Rd
@@ -8,11 +8,11 @@ inquire_blueprint(
   description,
   exp = NULL,
   group_col = "group",
-  model = NULL,
+  model = getOption("glysmith.ai_model", NULL),
   max_retries = 3,
-  provider = "deepseek",
-  api_key = NULL,
-  base_url = NULL
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  api_key = getOption("glysmith.ai_api_key", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 )
 }
 \arguments{
@@ -22,19 +22,21 @@ inquire_blueprint(
 
 \item{group_col}{The column name of the group variable in the experiment. Default to "group".}
 
-\item{model}{Model to use. Defaults to "deepseek-chat" for DeepSeek and
-the provider default for other providers.}
+\item{model}{Model to use. Defaults to \code{getOption("glysmith.ai_model")},
+or "deepseek-chat" for DeepSeek and the provider default for other providers.}
 
 \item{max_retries}{Maximum number of retries when the AI output is invalid. Default to 3.}
 
 \item{provider}{AI provider passed to \code{ellmer}. One of "deepseek",
 "openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
-Default to "deepseek".}
+Defaults to \code{getOption("glysmith.ai_provider", "deepseek")}.}
 
 \item{api_key}{API key for the selected provider. If \code{NULL}, the provider
-specific environment variable is used.}
+specific environment variable is used. Defaults to
+\code{getOption("glysmith.ai_api_key")}.}
 
-\item{base_url}{Optional base URL for custom or OpenAI-compatible endpoints.}
+\item{base_url}{Optional base URL for custom or OpenAI-compatible endpoints.
+Defaults to \code{getOption("glysmith.ai_base_url")}.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/inquire_blueprint.Rd
+++ b/man/inquire_blueprint.Rd
@@ -8,8 +8,11 @@ inquire_blueprint(
   description,
   exp = NULL,
   group_col = "group",
-  model = "deepseek-chat",
-  max_retries = 3
+  model = NULL,
+  max_retries = 3,
+  provider = "deepseek",
+  api_key = NULL,
+  base_url = NULL
 )
 }
 \arguments{
@@ -19,17 +22,26 @@ inquire_blueprint(
 
 \item{group_col}{The column name of the group variable in the experiment. Default to "group".}
 
-\item{model}{Model to use. Default to "deepseek-chat".}
+\item{model}{Model to use. Defaults to "deepseek-chat" for DeepSeek and
+the provider default for other providers.}
 
 \item{max_retries}{Maximum number of retries when the AI output is invalid. Default to 3.}
+
+\item{provider}{AI provider passed to \code{ellmer}. One of "deepseek",
+"openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
+Default to "deepseek".}
+
+\item{api_key}{API key for the selected provider. If \code{NULL}, the provider
+specific environment variable is used.}
+
+\item{base_url}{Optional base URL for custom or OpenAI-compatible endpoints.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 Ask a Large Language Model (LLM) to create a blueprint for glycomics or glycoproteomics data analysis.
-To use this function, you need to have a DeepSeek API key.
-You can get a DeepSeek API key from https://platform.deepseek.com.
-Then set the environment variable \code{DEEPSEEK_API_KEY} to your API key with
-\code{Sys.setenv(DEEPSEEK_API_KEY = "your-api-key")}.
+DeepSeek is used by default for backward compatibility. Other \code{ellmer}
+providers can be selected with \code{provider}, \code{model}, and provider-specific
+API key configuration.
 }
 \details{
 LLMs can be unstable. If you get an error, try again with another description.

--- a/man/modify_blueprint.Rd
+++ b/man/modify_blueprint.Rd
@@ -10,8 +10,11 @@ modify_blueprint(
   qa_history = NULL,
   exp = NULL,
   group_col = "group",
-  model = "deepseek-chat",
-  max_retries = 3
+  model = NULL,
+  max_retries = 3,
+  provider = "deepseek",
+  api_key = NULL,
+  base_url = NULL
 )
 }
 \arguments{
@@ -25,17 +28,26 @@ modify_blueprint(
 
 \item{group_col}{The column name of the group variable in the experiment. Default to "group".}
 
-\item{model}{Model to use. Default to "deepseek-chat".}
+\item{model}{Model to use. Defaults to "deepseek-chat" for DeepSeek and
+the provider default for other providers.}
 
 \item{max_retries}{Maximum number of retries when the AI output is invalid. Default to 3.}
+
+\item{provider}{AI provider passed to \code{ellmer}. One of "deepseek",
+"openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
+Default to "deepseek".}
+
+\item{api_key}{API key for the selected provider. If \code{NULL}, the provider
+specific environment variable is used.}
+
+\item{base_url}{Optional base URL for custom or OpenAI-compatible endpoints.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 Ask a Large Language Model (LLM) to modify an existing blueprint for glycomics
-or glycoproteomics data analysis. To use this function, you need to have a
-DeepSeek API key. You can get a DeepSeek API key from https://platform.deepseek.com.
-Then set the environment variable \code{DEEPSEEK_API_KEY} to your API key with
-\code{Sys.setenv(DEEPSEEK_API_KEY = "your-api-key")}.
+or glycoproteomics data analysis. DeepSeek is used by default for backward
+compatibility. Other \code{ellmer} providers can be selected with \code{provider},
+\code{model}, and provider-specific API key configuration.
 }
 \details{
 LLMs can be unstable. If you get an error, try again with another description.

--- a/man/modify_blueprint.Rd
+++ b/man/modify_blueprint.Rd
@@ -10,11 +10,11 @@ modify_blueprint(
   qa_history = NULL,
   exp = NULL,
   group_col = "group",
-  model = NULL,
+  model = getOption("glysmith.ai_model", NULL),
   max_retries = 3,
-  provider = "deepseek",
-  api_key = NULL,
-  base_url = NULL
+  provider = getOption("glysmith.ai_provider", "deepseek"),
+  api_key = getOption("glysmith.ai_api_key", NULL),
+  base_url = getOption("glysmith.ai_base_url", NULL)
 )
 }
 \arguments{
@@ -28,19 +28,21 @@ modify_blueprint(
 
 \item{group_col}{The column name of the group variable in the experiment. Default to "group".}
 
-\item{model}{Model to use. Defaults to "deepseek-chat" for DeepSeek and
-the provider default for other providers.}
+\item{model}{Model to use. Defaults to \code{getOption("glysmith.ai_model")},
+or "deepseek-chat" for DeepSeek and the provider default for other providers.}
 
 \item{max_retries}{Maximum number of retries when the AI output is invalid. Default to 3.}
 
 \item{provider}{AI provider passed to \code{ellmer}. One of "deepseek",
 "openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
-Default to "deepseek".}
+Defaults to \code{getOption("glysmith.ai_provider", "deepseek")}.}
 
 \item{api_key}{API key for the selected provider. If \code{NULL}, the provider
-specific environment variable is used.}
+specific environment variable is used. Defaults to
+\code{getOption("glysmith.ai_api_key")}.}
 
-\item{base_url}{Optional base URL for custom or OpenAI-compatible endpoints.}
+\item{base_url}{Optional base URL for custom or OpenAI-compatible endpoints.
+Defaults to \code{getOption("glysmith.ai_base_url")}.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/polish_report.Rd
+++ b/man/polish_report.Rd
@@ -10,10 +10,10 @@ polish_report(
   title = "GlySmith report",
   open = interactive(),
   use_ai = FALSE,
-  ai_provider = "deepseek",
-  ai_model = NULL,
-  ai_api_key = NULL,
-  ai_base_url = NULL
+  ai_provider = getOption("glysmith.ai_provider", "deepseek"),
+  ai_model = getOption("glysmith.ai_model", NULL),
+  ai_api_key = getOption("glysmith.ai_api_key", NULL),
+  ai_base_url = getOption("glysmith.ai_base_url", NULL)
 )
 }
 \arguments{
@@ -30,15 +30,19 @@ with the configured \code{ellmer} provider. Default is FALSE.}
 
 \item{ai_provider}{AI provider passed to \code{ellmer} when \code{use_ai = TRUE}.
 One of "deepseek", "openai", "anthropic", "gemini", "openrouter", or
-"openai_compatible". Default to "deepseek".}
+"openai_compatible". Defaults to
+\code{getOption("glysmith.ai_provider", "deepseek")}.}
 
 \item{ai_model}{AI model to use when \code{use_ai = TRUE}. Defaults to
-"deepseek-chat" for DeepSeek and the provider default for other providers.}
+\code{getOption("glysmith.ai_model")}, or "deepseek-chat" for DeepSeek and
+the provider default for other providers.}
 
 \item{ai_api_key}{API key for the selected provider. If \code{NULL}, the provider
-specific environment variable is used.}
+specific environment variable is used. Defaults to
+\code{getOption("glysmith.ai_api_key")}.}
 
-\item{ai_base_url}{Optional base URL for custom or OpenAI-compatible endpoints.}
+\item{ai_base_url}{Optional base URL for custom or OpenAI-compatible endpoints.
+Defaults to \code{getOption("glysmith.ai_base_url")}.}
 }
 \value{
 The normalized path to the generated HTML file.

--- a/man/polish_report.Rd
+++ b/man/polish_report.Rd
@@ -9,7 +9,11 @@ polish_report(
   output_file,
   title = "GlySmith report",
   open = interactive(),
-  use_ai = FALSE
+  use_ai = FALSE,
+  ai_provider = "deepseek",
+  ai_model = NULL,
+  ai_api_key = NULL,
+  ai_base_url = NULL
 )
 }
 \arguments{
@@ -22,7 +26,19 @@ polish_report(
 \item{open}{Whether to open the report in a browser after rendering.}
 
 \item{use_ai}{Whether to polish the report text, organize sections, and generate plot descriptions using AI
-(deepseek-chat and deepseek-vision). Default is FALSE.}
+with the configured \code{ellmer} provider. Default is FALSE.}
+
+\item{ai_provider}{AI provider passed to \code{ellmer} when \code{use_ai = TRUE}.
+One of "deepseek", "openai", "anthropic", "gemini", "openrouter", or
+"openai_compatible". Default to "deepseek".}
+
+\item{ai_model}{AI model to use when \code{use_ai = TRUE}. Defaults to
+"deepseek-chat" for DeepSeek and the provider default for other providers.}
+
+\item{ai_api_key}{API key for the selected provider. If \code{NULL}, the provider
+specific environment variable is used.}
+
+\item{ai_base_url}{Optional base URL for custom or OpenAI-compatible endpoints.}
 }
 \value{
 The normalized path to the generated HTML file.
@@ -30,11 +46,9 @@ The normalized path to the generated HTML file.
 \description{
 Generate a self-contained HTML report for a \code{glysmith_result} object.
 The report is rendered via \code{rmarkdown::render()} using an internal R Markdown template.
-If \code{use_ai} is TRUE, the report text will be polished and organized into sections using LLM (deepseek-chat),
-and plots will be described with a multimodal model (deepseek-vl-chat).
-To use this feature, you have to provide an API key and set it in the environment variable \code{DEEPSEEK_API_KEY}
-by running \code{Sys.setenv(DEEPSEEK_API_KEY = "your_api_key")}.
-You can apply the API key on https://platform.deepseek.com.
+If \code{use_ai} is TRUE, the report text will be polished, organized into
+sections, and paired with plot descriptions using the configured \code{ellmer}
+provider. DeepSeek is used by default for backward compatibility.
 }
 \examples{
 library(glyexp)

--- a/tests/testthat/test-inquire-blueprint.R
+++ b/tests/testthat/test-inquire-blueprint.R
@@ -187,6 +187,41 @@ test_that("inquire_blueprint handles valid output immediately (mocked)", {
   expect_equal(call_count, 1)
 })
 
+test_that("inquire_blueprint can use a non-DeepSeek provider", {
+  skip_if_not_installed("ellmer")
+  local_mock_glycan_fact()
+
+  captured <- list()
+  mock_chat_fun <- function(...) {
+    '{"explanation":"Overview then PCA.","steps":["step_ident_overview()","step_pca()"]}'
+  }
+
+  local_mocked_bindings(
+    chat_openai = function(system_prompt, model, echo, credentials) {
+      captured$system_prompt <<- system_prompt
+      captured$model <<- model
+      captured$key <<- credentials()
+      list(chat = mock_chat_fun)
+    },
+    .package = "ellmer"
+  )
+
+  withr::local_envvar(c(OPENAI_API_KEY = "openai-key"))
+
+  suppressMessages(
+    bp <- inquire_blueprint(
+      "test description",
+      provider = "openai",
+      model = "gpt-test"
+    )
+  )
+
+  expect_s3_class(bp, "glysmith_blueprint")
+  expect_named(bp, c("ident_overview", "pca"))
+  expect_equal(captured$model, "gpt-test")
+  expect_equal(captured$key, "openai-key")
+})
+
 test_that("inquire_blueprint retries on invalid output", {
   skip_if_not_installed("ellmer")
   local_mock_glycan_fact()
@@ -492,11 +527,18 @@ test_that("review_blueprint applies multiple refinements", {
       exp,
       group_col,
       model,
+      provider,
+      api_key,
+      base_url,
       max_retries
     ) {
       call_count <<- call_count + 1
       if (call_count == 1) {
         expect_equal(description, "add pca")
+        expect_equal(provider, "openai")
+        expect_equal(model, "gpt-test")
+        expect_equal(api_key, "key")
+        expect_null(base_url)
         return(bp_one)
       }
       expect_equal(description, "add heatmap")
@@ -512,7 +554,10 @@ test_that("review_blueprint applies multiple refinements", {
       qa_history = NULL,
       exp = NULL,
       group_col = "group",
-      model = "deepseek-reasoner",
+      model = "gpt-test",
+      provider = "openai",
+      api_key = "key",
+      base_url = NULL,
       max_retries = 1
     )
   )

--- a/tests/testthat/test-inquire-blueprint.R
+++ b/tests/testthat/test-inquire-blueprint.R
@@ -222,6 +222,38 @@ test_that("inquire_blueprint can use a non-DeepSeek provider", {
   expect_equal(captured$key, "openai-key")
 })
 
+test_that("inquire_blueprint uses package-level AI options", {
+  skip_if_not_installed("ellmer")
+  local_mock_glycan_fact()
+
+  captured <- list()
+  mock_chat_fun <- function(...) {
+    '{"explanation":"Overview then PCA.","steps":["step_ident_overview()","step_pca()"]}'
+  }
+
+  local_mocked_bindings(
+    chat_openai = function(system_prompt, model, echo, credentials) {
+      captured$model <<- model
+      captured$key <<- credentials()
+      list(chat = mock_chat_fun)
+    },
+    .package = "ellmer"
+  )
+
+  withr::local_envvar(c(OPENAI_API_KEY = "openai-key"))
+  withr::local_options(list(
+    glysmith.ai_provider = "openai",
+    glysmith.ai_model = "gpt-option"
+  ))
+
+  suppressMessages(bp <- inquire_blueprint("test description"))
+
+  expect_s3_class(bp, "glysmith_blueprint")
+  expect_named(bp, c("ident_overview", "pca"))
+  expect_equal(captured$model, "gpt-option")
+  expect_equal(captured$key, "openai-key")
+})
+
 test_that("inquire_blueprint retries on invalid output", {
   skip_if_not_installed("ellmer")
   local_mock_glycan_fact()

--- a/tests/testthat/test-modify-blueprint.R
+++ b/tests/testthat/test-modify-blueprint.R
@@ -28,6 +28,44 @@ test_that("modify_blueprint includes current blueprint in prompt", {
   expect_length(bp_updated, 3)
 })
 
+test_that("modify_blueprint can use a non-DeepSeek provider", {
+  skip_if_not_installed("ellmer")
+  local_mock_glycan_fact()
+
+  bp <- blueprint(step_preprocess())
+
+  captured <- list()
+  mock_chat_fun <- function(prompt) {
+    captured$prompt <<- prompt
+    "{\"explanation\":\"Add PCA.\",\"steps\":[\"step_preprocess()\",\"step_pca()\"]}"
+  }
+
+  local_mocked_bindings(
+    chat_anthropic = function(system_prompt, model, echo, credentials) {
+      captured$model <<- model
+      captured$key <<- credentials()
+      list(chat = mock_chat_fun)
+    },
+    .package = "ellmer"
+  )
+
+  withr::local_envvar(c(ANTHROPIC_API_KEY = "anthropic-key"))
+
+  suppressMessages(
+    bp_updated <- modify_blueprint(
+      bp,
+      "add pca",
+      provider = "anthropic",
+      model = "claude-test"
+    )
+  )
+
+  expect_s3_class(bp_updated, "glysmith_blueprint")
+  expect_equal(captured$model, "claude-test")
+  expect_equal(captured$key, "anthropic-key")
+  expect_true(grepl("step_preprocess\\(\\)", captured$prompt))
+})
+
 test_that("modify_blueprint retries on invalid output", {
   skip_if_not_installed("ellmer")
   local_mock_glycan_fact()

--- a/tests/testthat/test-polish-report.R
+++ b/tests/testthat/test-polish-report.R
@@ -490,6 +490,68 @@ test_that("build_report_sections passes AI provider configuration downstream", {
   expect_equal(captured$step_base_url, "https://example.test/v1")
 })
 
+test_that("build_report_sections uses package-level AI options", {
+  x <- structure(
+    list(
+      exp = list(),
+      data = list(),
+      plots = list(),
+      tables = list(),
+      meta = list(),
+      blueprint = structure(list(), class = "glysmith_blueprint")
+    ),
+    class = "glysmith_result"
+  )
+
+  captured <- list()
+  local_mocked_bindings(
+    .get_api_key = function(provider) {
+      captured$key_provider <<- provider
+      "provider-key"
+    },
+    .build_step_reports = function(
+      x,
+      use_ai = FALSE,
+      api_key = NULL,
+      provider = "deepseek",
+      model = NULL,
+      base_url = NULL
+    ) {
+      captured$step_provider <<- provider
+      captured$step_model <<- model
+      captured$step_base_url <<- base_url
+      list()
+    },
+    .build_plot_entries = function(
+      x,
+      use_ai = FALSE,
+      api_key = NULL,
+      provider = "deepseek",
+      model = NULL,
+      base_url = NULL
+    ) {
+      captured$plot_provider <<- provider
+      list()
+    },
+    .organize_report_sections = function(...) NULL,
+    .package = "glysmith"
+  )
+
+  withr::local_options(list(
+    glysmith.ai_provider = "openai",
+    glysmith.ai_model = "gpt-option",
+    glysmith.ai_base_url = "https://example.test/v1"
+  ))
+
+  suppressMessages(glysmith:::.build_report_sections(x, use_ai = TRUE))
+
+  expect_equal(captured$key_provider, "openai")
+  expect_equal(captured$step_provider, "openai")
+  expect_equal(captured$plot_provider, "openai")
+  expect_equal(captured$step_model, "gpt-option")
+  expect_equal(captured$step_base_url, "https://example.test/v1")
+})
+
 test_that("organize_report_sections returns NULL for empty inputs", {
   expect_null(glysmith:::.organize_report_sections(list(), list(), "key"))
 })

--- a/tests/testthat/test-polish-report.R
+++ b/tests/testthat/test-polish-report.R
@@ -360,7 +360,7 @@ test_that("build_step_reports uses AI polishing when enabled", {
   )
 
   local_mocked_bindings(
-    .polish_text = function(text, api_key, model = "deepseek-chat") {
+    .polish_text = function(text, api_key, ...) {
       paste0("polished: ", text)
     },
     .package = "glysmith"
@@ -397,7 +397,7 @@ test_that("build_plot_entries uses AI descriptions", {
       api_key,
       width = NULL,
       height = NULL,
-      model = "deepseek-chat"
+      ...
     ) {
       captured$label <<- label
       captured$description <<- description
@@ -413,6 +413,81 @@ test_that("build_plot_entries uses AI descriptions", {
   expect_equal(entries[[1]]$description, "AI desc")
   expect_equal(captured$api_key, "key")
   expect_true(grepl("Volcano plot", entries[[1]]$label, fixed = TRUE))
+})
+
+test_that("build_report_sections passes AI provider configuration downstream", {
+  x <- structure(
+    list(
+      exp = list(),
+      data = list(),
+      plots = list(),
+      tables = list(),
+      meta = list(),
+      blueprint = structure(list(), class = "glysmith_blueprint")
+    ),
+    class = "glysmith_result"
+  )
+
+  captured <- list()
+  local_mocked_bindings(
+    .get_api_key = function(provider) {
+      captured$key_provider <<- provider
+      "provider-key"
+    },
+    .build_step_reports = function(
+      x,
+      use_ai = FALSE,
+      api_key = NULL,
+      provider = "deepseek",
+      model = NULL,
+      base_url = NULL
+    ) {
+      captured$step_provider <<- provider
+      captured$step_model <<- model
+      captured$step_base_url <<- base_url
+      list()
+    },
+    .build_plot_entries = function(
+      x,
+      use_ai = FALSE,
+      api_key = NULL,
+      provider = "deepseek",
+      model = NULL,
+      base_url = NULL
+    ) {
+      captured$plot_provider <<- provider
+      list()
+    },
+    .organize_report_sections = function(
+      step_reports,
+      plot_entries,
+      api_key,
+      provider = "deepseek",
+      model = NULL,
+      base_url = NULL
+    ) {
+      captured$section_provider <<- provider
+      NULL
+    },
+    .package = "glysmith"
+  )
+
+  suppressMessages(
+    glysmith:::.build_report_sections(
+      x,
+      use_ai = TRUE,
+      provider = "openai",
+      model = "gpt-test",
+      base_url = "https://example.test/v1"
+    )
+  )
+
+  expect_equal(captured$key_provider, "openai")
+  expect_equal(captured$step_provider, "openai")
+  expect_equal(captured$plot_provider, "openai")
+  expect_equal(captured$section_provider, "openai")
+  expect_equal(captured$step_model, "gpt-test")
+  expect_equal(captured$step_base_url, "https://example.test/v1")
 })
 
 test_that("organize_report_sections returns NULL for empty inputs", {
@@ -515,7 +590,7 @@ test_that(".polish_text returns original text for NULL or empty input", {
 test_that(".polish_text calls ask_ai with correct prompts", {
   captured <- list()
   local_mocked_bindings(
-    .ask_ai = function(system_prompt, user_prompt, api_key, model) {
+    .ask_ai = function(system_prompt, user_prompt, api_key, model, ...) {
       captured$system_prompt <<- system_prompt
       captured$user_prompt <<- user_prompt
       "polished text"

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -107,6 +107,31 @@ test_that("ask_ai routes to configured ellmer provider", {
   expect_equal(captured$key, "key")
 })
 
+test_that("ask_ai uses package-level provider options", {
+  skip_if_not_installed("ellmer")
+
+  captured <- list()
+  local_mocked_bindings(
+    chat_openai = function(system_prompt, model, echo, credentials) {
+      captured$model <<- model
+      captured$key <<- credentials()
+      list(chat = function(prompt) "openai-response")
+    },
+    .package = "ellmer"
+  )
+
+  withr::local_options(list(
+    glysmith.ai_provider = "openai",
+    glysmith.ai_model = "gpt-option"
+  ))
+
+  response <- glysmith:::.ask_ai("sys", "user", "key")
+
+  expect_equal(response, "openai-response")
+  expect_equal(captured$model, "gpt-option")
+  expect_equal(captured$key, "key")
+})
+
 test_that("ask_ai supports OpenAI-compatible base URLs", {
   skip_if_not_installed("ellmer")
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -28,11 +28,24 @@ test_that("get_api_key reads from environment", {
   expect_equal(glysmith:::.get_api_key(), "test-key")
 })
 
+test_that("get_api_key reads provider-specific environment variables", {
+  withr::local_envvar(c(OPENAI_API_KEY = "openai-key"))
+  expect_equal(glysmith:::.get_api_key(provider = "openai"), "openai-key")
+})
+
 test_that("get_api_key errors when missing", {
   withr::local_envvar(c(DEEPSEEK_API_KEY = ""))
   expect_error(
     glysmith:::.get_api_key(),
     "API key for DeepSeek chat model is not set"
+  )
+})
+
+test_that("get_api_key errors with provider-specific guidance", {
+  withr::local_envvar(c(OPENAI_API_KEY = ""))
+  expect_error(
+    glysmith:::.get_api_key(provider = "openai"),
+    "OPENAI_API_KEY"
   )
 })
 
@@ -59,6 +72,80 @@ test_that("ask_ai uses ellmer chat", {
   expect_equal(captured$system_prompt, "sys")
   expect_equal(captured$user_prompt, "user")
   expect_equal(captured$key, "key")
+})
+
+test_that("ask_ai routes to configured ellmer provider", {
+  skip_if_not_installed("ellmer")
+
+  captured <- list()
+  local_mocked_bindings(
+    chat_openai = function(system_prompt, model, echo, credentials) {
+      captured$system_prompt <<- system_prompt
+      captured$model <<- model
+      captured$echo <<- echo
+      captured$key <<- credentials()
+      list(chat = function(prompt) {
+        captured$user_prompt <<- prompt
+        "openai-response"
+      })
+    },
+    .package = "ellmer"
+  )
+
+  response <- glysmith:::.ask_ai(
+    "sys",
+    "user",
+    "key",
+    provider = "openai",
+    model = "gpt-test"
+  )
+
+  expect_equal(response, "openai-response")
+  expect_equal(captured$system_prompt, "sys")
+  expect_equal(captured$user_prompt, "user")
+  expect_equal(captured$model, "gpt-test")
+  expect_equal(captured$key, "key")
+})
+
+test_that("ask_ai supports OpenAI-compatible base URLs", {
+  skip_if_not_installed("ellmer")
+
+  captured <- list()
+  local_mocked_bindings(
+    chat_openai_compatible = function(
+      base_url,
+      name,
+      system_prompt,
+      model,
+      echo,
+      credentials
+    ) {
+      captured$base_url <<- base_url
+      captured$name <<- name
+      captured$system_prompt <<- system_prompt
+      captured$model <<- model
+      captured$key <<- credentials()
+      list(chat = function(prompt) {
+        captured$user_prompt <<- prompt
+        "compatible-response"
+      })
+    },
+    .package = "ellmer"
+  )
+
+  response <- glysmith:::.ask_ai(
+    "sys",
+    "user",
+    "key",
+    provider = "openai_compatible",
+    model = "custom-model",
+    base_url = "https://example.test/v1"
+  )
+
+  expect_equal(response, "compatible-response")
+  expect_equal(captured$base_url, "https://example.test/v1")
+  expect_equal(captured$name, "OpenAI-compatible")
+  expect_equal(captured$model, "custom-model")
 })
 
 test_that("ask_ai_multimodal passes content to chat", {

--- a/vignettes/ai.Rmd
+++ b/vignettes/ai.Rmd
@@ -42,7 +42,23 @@ bp <- inquire_blueprint(
 )
 ```
 
+If you prefer to configure the provider once per R session, use package-level options:
+
+```r
+options(
+  glysmith.ai_provider = "openai",
+  glysmith.ai_model = "gpt-4.1"
+)
+
+bp <- inquire_blueprint(
+  "I want to perform DEA and visualize the results.",
+  exp = your_exp
+)
+```
+
 For OpenAI-compatible endpoints, set `OPENAI_API_KEY` and pass both `provider = "openai_compatible"` and `base_url`.
+The corresponding options are `glysmith.ai_provider`, `glysmith.ai_model`,
+`glysmith.ai_api_key`, and `glysmith.ai_base_url`.
 
 *Note: This environment variable is session-specific. You will need to set it again in new R sessions, or add it to your `.Renviron` file for a permanent setup.*
 

--- a/vignettes/ai.Rmd
+++ b/vignettes/ai.Rmd
@@ -20,14 +20,29 @@ AI integration allows you to focus on the science while it handles the boilerpla
 
 ## Getting Started
 
-To enable AI features, you need a DeepSeek API key.
-You can obtain one from the [DeepSeek Platform](https://platform.deepseek.com).
+To enable AI features, configure an API key for the LLM provider you want to use.
+DeepSeek is the default provider, and you can obtain a key from the [DeepSeek Platform](https://platform.deepseek.com).
 
 Once you have your key, set it as an environment variable in your R session:
 
 ```r
 Sys.setenv(DEEPSEEK_API_KEY = "your_api_key")
 ```
+
+You can also use other providers supported by `ellmer`.
+For example, OpenAI can be used by setting `OPENAI_API_KEY` and passing `provider = "openai"`:
+
+```r
+Sys.setenv(OPENAI_API_KEY = "your_api_key")
+bp <- inquire_blueprint(
+  "I want to perform DEA and visualize the results.",
+  exp = your_exp,
+  provider = "openai",
+  model = "gpt-4.1"
+)
+```
+
+For OpenAI-compatible endpoints, set `OPENAI_API_KEY` and pass both `provider = "openai_compatible"` and `base_url`.
 
 *Note: This environment variable is session-specific. You will need to set it again in new R sessions, or add it to your `.Renviron` file for a permanent setup.*
 
@@ -82,6 +97,18 @@ setting `use_ai = TRUE` unlocks advanced AI capabilities for report generation:
 
 ```r
 polish_report(result, "report.html", use_ai = TRUE)
+```
+
+To use a non-default provider for reporting, pass the `ai_` configuration arguments:
+
+```r
+polish_report(
+  result,
+  "report.html",
+  use_ai = TRUE,
+  ai_provider = "openai",
+  ai_model = "gpt-4.1"
+)
 ```
 
 In AI mode, the LLM performs several high-level tasks:


### PR DESCRIPTION
## Summary
- Add a provider-configurable `ellmer` backend for glysmith AI helpers, keeping DeepSeek as the default for backward compatibility.
- Support non-DeepSeek providers including OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible endpoints.
- Wire provider/model/API-key/base-URL configuration through blueprint generation, blueprint modification, and AI report polishing.
- Add package-level options (`glysmith.ai_provider`, `glysmith.ai_model`, `glysmith.ai_api_key`, `glysmith.ai_base_url`) so users can configure AI defaults once per session.
- Refresh the AI vignette, roxygen docs, generated Rd files, and tests for both explicit provider arguments and option-based defaults.

## Commit scope
- `37f7855` adds the provider-configurable AI backend and non-DeepSeek provider support.
- `94256fa` adds package-level AI provider options on top of that backend.

## Testing
- `Rscript -e 'devtools::load_all(); devtools::test(filter = "utils|inquire-blueprint|modify-blueprint|polish-report")'`
- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::load_all(); devtools::test()'`
- `git diff --check`