### PR TITLE
fix: stop quench_result from generating stray Rplots.pdf

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 * `check_glysmith_deps()` now checks only the packages required by the supplied blueprint, instead of asking users to install every optional dependency. Step-specific glycoverse packages are optional again, with installation guidance for the glycoverse r-universe repository (#17).
 * Enrichment analysis now uses `glyfun` instead of `glystats`, as enrichment analysis functions in `glystats` have been deprecated in favor of `glyfun` (#10).
+* `quench_result()` no longer leaves a stray `Rplots.pdf` in the working directory (#18).
 
 # glysmith 0.10.1
 

--- a/R/quench-result.R
+++ b/R/quench-result.R
@@ -55,21 +55,17 @@ quench_result <- function(
       # New format: list with plot, width, height
       width <- plot_obj$width %||% plot_width
       height <- plot_obj$height %||% plot_height
-      # Force evaluation to handle lazy promises on older R versions
-      plot_to_save <- ggplot2::ggplotGrob(plot_obj$plot)
       .quietly(ggplot2::ggsave(
         file_path,
-        plot_to_save,
+        plot = plot_obj$plot,
         width = width,
         height = height
       ))
     } else {
       # Legacy format: just the ggplot object
-      # Force evaluation to handle lazy promises on older R versions
-      plot_to_save <- ggplot2::ggplotGrob(cast_plot(x, plot))
       .quietly(ggplot2::ggsave(
         file_path,
-        plot_to_save,
+        plot = cast_plot(x, plot),
         width = plot_width,
         height = plot_height
       ))

--- a/tests/testthat/test-quench-result.R
+++ b/tests/testthat/test-quench-result.R
@@ -143,6 +143,26 @@ test_that("quench_result rejects invalid overwrite input", {
   expect_true(fs::file_exists(sentinel))
 })
 
+test_that("quench_result does not create stray Rplots.pdf", {
+  x <- glysmith_result(
+    exp = list(dummy = TRUE),
+    plots = list(
+      scatter = ggplot2::ggplot(mtcars, ggplot2::aes(mpg, wt)) +
+        ggplot2::geom_point()
+    ),
+    tables = list(),
+    meta = list(),
+    data = list(),
+    blueprint = new_blueprint(list(step_pca()))
+  )
+
+  withr::local_dir(withr::local_tempdir())
+  suppressWarnings(suppressMessages(
+    quench_result(x, "quench-out", plot_ext = "png")
+  ))
+  expect_false(fs::file_exists("Rplots.pdf"))
+})
+
 test_that("write_result_readme falls back when explanations are empty", {
   x <- glysmith_result(
     exp = list(),


### PR DESCRIPTION
## Summary
- `quench_result()` called `ggplot2::ggplotGrob()` before `ggsave()`, which triggered R to open the default graphics device (`Rplots.pdf`) when no device was active. This left a stray empty `Rplots.pdf` in the user's working directory.
- Removed the unnecessary `ggplotGrob()` indirection and passed ggplot objects directly to `ggsave()`.

## Test plan
- [x] `devtools::test()` — 700 pass, 0 fail, 0 warn
- [x] Verified no `Rplots.pdf` appears after calling `quench_result()` with real data