### PR TITLE
Fix ANOVA and Kruskal boxplot ranking in step_sig_boxplot

### DIFF
--- a/R/step-visualization.R
+++ b/R/step-visualization.R
@@ -359,7 +359,7 @@ step_sig_boxplot <- function(
       sig_branch_motif_exp = "branch_dma_res"
     )
     dea_res <- ctx_get_data(ctx, dea_key)
-    tidy_res <- glystats::get_tidy_result(dea_res)
+    tidy_res <- .get_sig_boxplot_tidy_result(dea_res)
 
     top_vars <- tidy_res |>
       dplyr::arrange(dplyr::across(dplyr::matches("p_adj"))) |>
@@ -428,4 +428,18 @@ step_sig_boxplot <- function(
   height <- max(min_height, min(height, max_height))
 
   list(width = width, height = height)
+}
+
+#' Get DEA result table used to rank significant boxplot variables
+#'
+#' @param dea_res A glystats differential-analysis result object.
+#'
+#' @returns A tidy result table.
+#' @noRd
+.get_sig_boxplot_tidy_result <- function(dea_res) {
+  if (inherits(dea_res, c("glystats_anova_res", "glystats_kruskal_res"))) {
+    return(glystats::get_tidy_result(dea_res, which = "main_test"))
+  }
+
+  glystats::get_tidy_result(dea_res)
 }

--- a/tests/testthat/test-step-visualization.R
+++ b/tests/testthat/test-step-visualization.R
@@ -133,6 +133,21 @@ test_that("step_sig_boxplot works with step_dea_anova", {
   expect_true("sig_boxplot_sig" %in% names(res$plots))
 })
 
+test_that("step_sig_boxplot ranks top variables after step_dea_anova", {
+  suppressMessages(
+    exp <- glyexp::real_experiment |>
+      glyexp::slice_head_var(50) |>
+      glyclean::auto_clean()
+  )
+  bp <- blueprint(
+    step_dea_anova(filter_p_adj_cutoff = 1),
+    step_sig_boxplot()
+  )
+  suppressMessages(res <- forge_analysis(exp, bp))
+  expect_true(nrow(res$data$sig_exp) > 25)
+  expect_true("sig_boxplot_sig" %in% names(res$plots))
+})
+
 test_that("step_sig_boxplot works with step_dea_kruskal", {
   skip_if_not_installed("FSA")
   suppressMessages(
@@ -145,5 +160,21 @@ test_that("step_sig_boxplot works with step_dea_kruskal", {
     step_sig_boxplot()
   )
   suppressMessages(res <- forge_analysis(exp, bp))
+  expect_true("sig_boxplot_sig" %in% names(res$plots))
+})
+
+test_that("step_sig_boxplot ranks top variables after step_dea_kruskal", {
+  skip_if_not_installed("FSA")
+  suppressMessages(
+    exp <- glyexp::real_experiment |>
+      glyexp::slice_head_var(50) |>
+      glyclean::auto_clean()
+  )
+  bp <- blueprint(
+    step_dea_kruskal(filter_p_adj_cutoff = 1),
+    step_sig_boxplot()
+  )
+  suppressMessages(res <- forge_analysis(exp, bp))
+  expect_true(nrow(res$data$sig_exp) > 25)
   expect_true("sig_boxplot_sig" %in% names(res$plots))
 })


### PR DESCRIPTION
## Summary
- Route ANOVA and Kruskal DEA results through the main-test tidy table before ranking significant boxplot variables.
- Add regression coverage for the `>25` significant-variable path for both ANOVA and Kruskal blueprints.

## Testing
- Focused `step-visualization` tests passed.
- Full `devtools::test()` passed locally.
- `devtools::document()`, `air format .`, and `git diff --check` passed.